### PR TITLE
Fix country codes.

### DIFF
--- a/countrycodepicker/src/main/res/values/strings_country.xml
+++ b/countrycodepicker/src/main/res/values/strings_country.xml
@@ -638,7 +638,7 @@
 
     <string name="country_norfolk_island_name">Norfolk Island</string>
     <string name="country_norfolk_island_code" translatable="false">nf</string>
-    <string name="country_norfolk_island_number" translatable="false">1670</string>
+    <string name="country_norfolk_island_number" translatable="false">672</string>
 
     <string name="country_northern_mariana_islands_name">Northern Mariana Islands</string>
     <string name="country_northern_mariana_islands_code" translatable="false">mp</string>

--- a/countrycodepicker/src/main/res/values/strings_country.xml
+++ b/countrycodepicker/src/main/res/values/strings_country.xml
@@ -642,7 +642,7 @@
 
     <string name="country_northern_mariana_islands_name">Northern Mariana Islands</string>
     <string name="country_northern_mariana_islands_code" translatable="false">mp</string>
-    <string name="country_northern_mariana_islands_number" translatable="false">850</string>
+    <string name="country_northern_mariana_islands_number" translatable="false">1670</string>
 
     <string name="country_norway_name">Norway</string>
     <string name="country_norway_code" translatable="false">no</string>

--- a/countrycodepicker/src/main/res/values/strings_country.xml
+++ b/countrycodepicker/src/main/res/values/strings_country.xml
@@ -78,7 +78,7 @@
 
     <string name="country_barbados_name">Barbados</string>
     <string name="country_barbados_code" translatable="false">bb</string>
-    <string name="country_barbados_number" translatable="false">1242</string>
+    <string name="country_barbados_number" translatable="false">1246</string>
 
     <string name="country_belarus_name">Belarus</string>
     <string name="country_belarus_code" translatable="false">by</string>

--- a/countrycodepicker/src/main/res/values/strings_country.xml
+++ b/countrycodepicker/src/main/res/values/strings_country.xml
@@ -686,7 +686,7 @@
 
     <string name="country_pitcairn_name">Pitcairn</string>
     <string name="country_pitcairn_code" translatable="false">pn</string>
-    <string name="country_pitcairn_number" translatable="false">870</string>
+    <string name="country_pitcairn_number" translatable="false">64</string>
 
     <string name="country_poland_name">Poland</string>
     <string name="country_poland_code" translatable="false">pl</string>

--- a/countrycodepicker/src/main/res/values/strings_country.xml
+++ b/countrycodepicker/src/main/res/values/strings_country.xml
@@ -162,7 +162,7 @@
 
     <string name="country_cayman_islands_name">Cayman Islands</string>
     <string name="country_cayman_islands_code" translatable="false">ky</string>
-    <string name="country_cayman_islands_number" translatable="false">345</string>
+    <string name="country_cayman_islands_number" translatable="false">1345</string>
 
     <string name="country_central_african_republic_name">Central African Republic</string>
     <string name="country_central_african_republic_code" translatable="false">cf</string>


### PR DESCRIPTION
The following country codes seem to be incorrect - 

Barbados - https://countrycode.org/barbados
Cayman Islands - https://countrycode.org/caymanislands
Norfold Islands
Northern Mariana Islands - https://countrycode.org/northernmarianaislands
 Pitcairn Islands - https://countrycode.org/pitcairnislands